### PR TITLE
feat(accounts): add /me endpoint with authenticated player profile + API tests

### DIFF
--- a/backend/accounts/tests/test_me_endpoint.py
+++ b/backend/accounts/tests/test_me_endpoint.py
@@ -1,0 +1,61 @@
+from django.contrib.auth import get_user_model
+
+from rest_framework.test import APITestCase
+from rest_framework_simplejwt.tokens import RefreshToken
+
+from accounts.models import PlayerCharacter
+
+User = get_user_model()
+
+
+class MeEndpointTests(APITestCase):
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="testuser",
+            email="test@example.com",
+            password="testpass123"
+        )
+
+        self.character = PlayerCharacter.objects.create(
+            user=self.user,
+            name="Hero",
+            level=1,
+            experience=0,
+            health=100,
+            max_health=100,
+            mana=50,
+            max_mana=50,
+            strength=10,
+            dexterity=10,
+            intelligence=10,
+        )
+
+    def authenticate(self):
+        refresh = RefreshToken.for_user(self.user)
+
+        self.client.credentials(
+            HTTP_AUTHORIZATION=f"Bearer {refresh.access_token}"
+        )
+
+    def test_me_endpoint_returns_user_profile(self):
+        self.authenticate()
+
+        response = self.client.get("/api/accounts/me/")
+
+        self.assertEqual(response.status_code, 200)
+
+        self.assertEqual(
+            response.data["user"]["username"],
+            "testuser"
+        )
+
+        self.assertEqual(
+            response.data["character"]["name"],
+            "Hero"
+        )
+
+    def test_me_endpoint_requires_authentication(self):
+        response = self.client.get("/api/accounts/me/")
+
+        self.assertEqual(response.status_code, 401)

--- a/backend/accounts/urls.py
+++ b/backend/accounts/urls.py
@@ -4,6 +4,8 @@ from accounts.views import PlayerCharacterViewSet
 from users.views import UserRegisterView, UserLoginView
 from rest_framework_simplejwt.views import TokenRefreshView
 
+from .views import MeView
+
 router = DefaultRouter()
 router.register(r'characters', PlayerCharacterViewSet, basename='characters')
 
@@ -12,5 +14,6 @@ urlpatterns = [
 	path('register/', UserRegisterView.as_view(), name='register'),
 	path('login/', UserLoginView.as_view(), name='login'),
 	path('token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
+	path('me/', MeView.as_view(), name='me'),
 	path('', include(router.urls)),
 ]

--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -3,15 +3,36 @@ from .models import PlayerCharacter
 from .serializers import PlayerCharacterSerializer
 from rest_framework.permissions import IsAuthenticated
 
+from rest_framework.views import APIView
+from rest_framework.response import Response
+
 
 class PlayerCharacterViewSet(viewsets.ModelViewSet):
     serializer_class = PlayerCharacterSerializer
     permission_classes = [IsAuthenticated]
-    queryset = PlayerCharacter.objects.all()
 
     def get_queryset(self):
         return PlayerCharacter.objects.select_related('user').filter(user=self.request.user)
     
     def perform_create(self, serializer):
         serializer.save(user=self.request.user)
-    
+
+
+class MeView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        user = request.user
+
+        character = PlayerCharacter.objects.filter(user=user).first()
+
+        return Response({
+            "user": {
+                "id": user.id,
+                "username": user.username,
+                "email": user.email,
+            },
+            "character": PlayerCharacterSerializer(character).data 
+            if character is not None
+            else None
+        })


### PR DESCRIPTION

```text
feat(accounts): add /me endpoint with authenticated player profile + API tests
```

---

````text
## Summary
Adds authenticated `/api/accounts/me/` endpoint that returns:
- user data
- linked PlayerCharacter data

This endpoint is used for frontend profile page and player dashboard.

---

## Changes
- Added `/me/` endpoint in accounts API
- Integrated JWT authentication (SimpleJWT)
- Returned combined user + character payload
- Added DRF API tests for endpoint:
  - authenticated request returns 200
  - unauthenticated request returns 401
- Ensured user-scoped access to PlayerCharacter

---

## API Response Example
```json
{
  "user": {
    "id": 1,
    "username": "marpot",
    "email": "example@mail.com"
  },
  "character": {
    "id": 1,
    "name": "Hero",
    "level": 1,
    "health": 100
  }
}
````

---

## Tests

* accounts.tests.test_me_endpoint
* covers authentication and response structure

---

## Security

* Endpoint requires authentication (IsAuthenticated)
* Data scoped to request.user only

---

## Notes

This endpoint is intended as a foundation for:

* Profile page (React)
* Player dashboard UI
* Future character management features

```