### PR TITLE
feat(llm): add Groq intent parser with contract testsFeature/llm core groq adapter

### DIFF
--- a/backend/game/tests/test_combat_flow_integration.py
+++ b/backend/game/tests/test_combat_flow_integration.py
@@ -13,28 +13,8 @@ def test_full_combat_flow():
     state = GameStateManager()
     processor = ActionProcessor(state)
 
-    room = state.get_or_create_room("testroom")
-
     # =========================
-    # runtime player (combat layer)
-    # =========================
-    state.add_player(
-        "testroom",
-        1,
-        Player(
-            id=1,
-            name="Hero",
-            hp=100,
-            max_hp=100,
-            attack_bonus=10,
-            damage_die=8,
-            damage_bonus=2,
-            defense=5
-        )
-    )
-
-    # =========================
-    # Django user
+    # Django user (MUSI BYĆ PIERWSZY)
     # =========================
     User = get_user_model()
     user = User.objects.create_user(username="hero", password="x")
@@ -52,6 +32,26 @@ def test_full_combat_flow():
     adventure = Adventure.objects.create(
         title="test",
         creator=user
+    )
+
+    # =========================
+    # runtime player (combat layer)
+    # =========================
+    room = state.get_or_create_room("testroom")
+
+    state.add_player(
+        "testroom",
+        user.id,
+        Player(
+            id=user.id,
+            name="Hero",
+            hp=100,
+            max_hp=100,
+            attack_bonus=10,
+            damage_die=8,
+            damage_bonus=2,
+            defense=5
+        )
     )
 
     # =========================
@@ -90,6 +90,7 @@ def test_full_combat_flow():
         "user_id": user.id,
         "adventure": adventure.id
     })
+
     # =========================
     # ASSERT
     # =========================

--- a/backend/game/tests/test_entity_resolver.py
+++ b/backend/game/tests/test_entity_resolver.py
@@ -25,7 +25,11 @@ class FakeStateManager:
     def get_room(self, name):
         return self.rooms.get(name)
 
-
+    # 🔥 FIX: kompatybilność z production API
+    def get_or_create_room(self, name):
+        if name not in self.rooms:
+            self.create_room(name)
+        return self.rooms[name]
 # -------------------------
 # TESTS
 # -------------------------

--- a/backend/game_instances/services/llm/llm_client.py
+++ b/backend/game_instances/services/llm/llm_client.py
@@ -1,7 +1,12 @@
+from openai import OpenAI
+import os
+
 class LLMClient:
-    """
-    Mock warstwa LLM
-    """
+    def __init__(self):
+        self.client = OpenAI(
+            api_key=os.getenv("GROQ_API_KEY")
+            base_url=os.getenv("GROQ_API_BASE_URL")
+        )
 
     def generate(self, prompt:str) -> str:
         return f"[MOCK LLM RESPONSE]: {prompt}"

--- a/backend/game_instances/services/llm/llm_client.py
+++ b/backend/game_instances/services/llm/llm_client.py
@@ -4,10 +4,74 @@ import os
 class LLMClient:
     def __init__(self):
         self.client = OpenAI(
-            api_key=os.getenv("GROQ_API_KEY")
-            base_url=os.getenv("GROQ_API_BASE_URL")
+            api_key=os.getenv("GROQ_API_KEY"),
+            base_url=os.getenv("GROQ_API_BASE_URL", "https://api.groq.com/openai/v1"),
         )
 
+        self.model = "llama-3.3-70b-versatile"
+
     def generate(self, prompt:str) -> str:
-        return f"[MOCK LLM RESPONSE]: {prompt}"
-    
+        response = self.client.chat.completions.create(
+            model=self.model,
+            messages=[
+            {
+                    "role": "system",
+                    "content": """
+                    
+                You are an RPG intent parser.
+
+                Your ONLY task is to convert user input into a strict JSON command.
+
+                RULES:
+                - Output MUST be valid JSON
+                - Output MUST contain ONLY these fields:
+                - action (string)
+                - target (string or null)
+                - method (string or null)
+
+                ALLOWED ACTIONS:
+                - move
+                - attack
+                - defend
+                - talk
+                - inspect
+                - use_item
+
+                STRICT RULES:
+                - Do NOT generate narrative text
+                - Do NOT calculate damage or game state
+                - Do NOT include HP, stats, or outcomes
+                - Do NOT include explanations
+                - Do NOT output markdown or extra text
+                - If uncertain, default to action="inspect"
+
+                EXAMPLES:
+
+                Input: "attack goblin"
+                Output:
+                {"action":"attack","target":"goblin","method":null}
+
+                Input: "attack goblin with spell"
+                Output:
+                {"action":"attack","target":"goblin","method":"spell"}
+
+                Input: "go north"
+                Output:
+                {"action":"move","target":"north","method":null}
+
+                Input: "look around"
+                Output:
+                {"action":"inspect","target":"environment","method":null}
+                """
+                },
+
+                {
+                    "role": "user",
+                    "content": prompt
+                }
+            ],
+            temperature=0.2,
+            max_tokens=80,
+        )
+
+        return response.choices[0].message.content

--- a/backend/game_instances/tests/test_llm_client.py
+++ b/backend/game_instances/tests/test_llm_client.py
@@ -1,0 +1,65 @@
+import json
+import pytest
+from game_instances.services.llm.llm_client import LLMClient
+
+pytestmark = pytest.mark.django_db
+
+
+def test_llm_returns_valid_intent_json():
+    llm_client = LLMClient()
+
+    player_input = "attack goblin with spell"
+    response_text = llm_client.generate(player_input)
+
+    intent = json.loads(response_text)
+
+    assert "action" in intent
+    assert "target" in intent
+    assert "method" in intent
+
+
+def test_llm_maps_inputs_to_allowed_actions():
+    llm_client = LLMClient()
+
+    test_inputs = [
+        "attack goblin",
+        "go north",
+        "look around",
+        "attack goblin with spell",
+    ]
+
+    allowed_actions = {
+        "attack",
+        "move",
+        "inspect",
+        "talk",
+        "defend",
+        "use_item",
+    }
+
+    for player_input in test_inputs:
+        response_text = llm_client.generate(player_input)
+        intent = json.loads(response_text)
+
+        assert isinstance(intent["action"], str)
+        assert intent["action"] in allowed_actions
+
+        assert isinstance(intent.get("target"), (str, type(None)))
+        assert isinstance(intent.get("method"), (str, type(None)))
+
+
+def test_llm_does_not_return_game_state():
+    llm_client = LLMClient()
+
+    response_text = llm_client.generate("attack goblin")
+
+    forbidden_fields = [
+        "hp",
+        "health",
+        "damage",
+        "result",
+        "message",
+    ]
+
+    for field in forbidden_fields:
+        assert field not in response_text

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -39,6 +39,8 @@ mdurl==0.1.2
 msgpack==1.1.0
 multidict==6.1.0
 
+openai>=1.30.0
+
 packaging==24.2
 pluggy==1.5.0
 priority==1.3.0


### PR DESCRIPTION
- Add Groq LLM client integration
- Implement strict intent-only system prompt
- Add JSON contract tests for LLM output
- Ensure no game logic leakage into LLM layer

LLM now acts as intent parser only (no game state logic).